### PR TITLE
Fix Polars::Series#[] with negative numbers

### DIFF
--- a/lib/polars/series.rb
+++ b/lib/polars/series.rb
@@ -317,6 +317,10 @@ module Polars
       end
 
       if item.is_a?(Integer)
+        if item < 0
+          item = len + item
+        end
+
         return _s.get_idx(item)
       end
 

--- a/test/series_test.rb
+++ b/test/series_test.rb
@@ -281,6 +281,7 @@ class SeriesTest < Minitest::Test
   def test_get
     s = Polars::Series.new(1..3)
     assert_equal 2, s[1]
+    assert_equal 3, s[-1]
     assert_series [1, 2], s[[0, 1]]
     assert_series [1, 2], s[Polars::Series.new([0, 1])]
     assert_series [1], s[0..0]


### PR DESCRIPTION
This pull request fixes the `RangeError` when calling `Polars.last` or `Polars::Series#[]` with negative numbers.

```ruby
irb(main):001:0> s = Polars::Series.new([1,2,3])
=> shape: (3,)
irb(main):002:0> Polars.last(s)
/Users/wagner/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/bundler/gems/polars-ruby-5e7c1f5ab040/lib/polars/series.rb:320:in `get_idx': can't convert negative integer to unsigned (RangeError)
```

The fix implements the existing strategy on py-polars: https://github.com/pola-rs/polars/blob/134d43edeb5d462a77b8d6475ea7746a44656342/py-polars/polars/series/series.py#L969-L972