### PR TITLE
Pass false to Rust binding for vertical concat of lazy frames

### DIFF
--- a/lib/polars/functions.rb
+++ b/lib/polars/functions.rb
@@ -62,9 +62,10 @@ module Polars
           raise ArgumentError, "how must be one of {{'vertical', 'diagonal', 'horizontal'}}, got #{how}"
         end
       elsif first.is_a?(LazyFrame)
+        # TODO: Implement the rest of the logic in Python:
+        # https://github.com/pola-rs/polars/blob/rs-0.31.1/py-polars/polars/functions/eager.py#L170-L179
         if how == "vertical"
-          # TODO
-          return Utils.wrap_ldf(_concat_lf(items, rechunk, parallel))
+          return Utils.wrap_ldf(_concat_lf(items, rechunk, parallel, false))
         else
           raise ArgumentError, "Lazy only allows 'vertical' concat strategy."
         end


### PR DESCRIPTION
I was trying to concatenate two LazyFrame's together and I was getting an error about not passing enough arguments in. I discovered we weren't forwarding the `to_supertype` argument to the underlying Rust binding.

~I added `true` as a default argument but I have no opinions about what the default should be, so I'm happy to change it if anyone suggests otherwise.~

Passing false for vertical concatenation following the [logic in the Python library](https://github.com/pola-rs/polars/blob/rs-0.31.1/py-polars/polars/functions/eager.py#L170-L179)