### PR TITLE
Add Series#none?

### DIFF
--- a/lib/polars/series.rb
+++ b/lib/polars/series.rb
@@ -432,6 +432,18 @@ module Polars
     end
     alias_method :all, :all?
 
+    # Check if all boolean values in the column are `false`.
+    #
+    # @return [Boolean]
+    def none?(&block)
+      if block_given?
+        apply(&block).none?
+      else
+        to_frame.select(Polars.col(name).is_not.all).to_series[0]
+      end
+    end
+    alias_method :none, :none?
+
     # Compute the logarithm to a given base.
     #
     # @param base [Float]

--- a/test/series_test.rb
+++ b/test/series_test.rb
@@ -338,6 +338,13 @@ class SeriesTest < Minitest::Test
     assert Polars::Series.new([2, 4, 6]).all?(&:even?)
   end
 
+  def test_none
+    assert Polars::Series.new([false, false, false]).none?
+    refute Polars::Series.new([false, true, false]).none?
+    assert Polars::Series.new([1, 3, 5]).none?(&:even?)
+    refute Polars::Series.new([2, 3, 5]).none?(&:even?)
+  end
+
   def test_log
     s = Polars::Series.new([1, 2, 4])
     assert_series [0, 1, 2], s.log(2)


### PR DESCRIPTION
I don't know if you are willing to include methods that don't exist in original Python/Rust versions, but as we have `Series#all?`, I thought it would be nice to have `Series#none?` (inspired by Ruby's `Enumerable#none?`).