### PR TITLE
Fix ArgumentError typo

### DIFF
--- a/lib/polars/data_frame.rb
+++ b/lib/polars/data_frame.rb
@@ -5096,10 +5096,10 @@ module Polars
 
     def _compare_to_other_df(other, op)
       if columns != other.columns
-        raise ArgmentError, "DataFrame columns do not match"
+        raise ArgumentError, "DataFrame columns do not match"
       end
       if shape != other.shape
-        raise ArgmentError, "DataFrame dimensions do not match"
+        raise ArgumentError, "DataFrame dimensions do not match"
       end
 
       suffix = "__POLARS_CMP_OTHER"

--- a/test/data_frame_test.rb
+++ b/test/data_frame_test.rb
@@ -157,6 +157,15 @@ class DataFrameTest < Minitest::Test
     assert_frame ({"a" => [false, true, true, true]}), a <= b
   end
 
+  def test_comp_data_frame_different_schema
+    a = Polars::DataFrame.new({"a" => [1]})
+    b = Polars::DataFrame.new({"b" => [1]})
+    error = assert_raises(ArgumentError) do
+      a == b
+    end
+    assert_match "DataFrame columns do not match", error.message
+  end
+
   def test_comp_scalar
     a = Polars::DataFrame.new({"a" => [1, 2, 3]})
     assert_frame ({"a" => [false, true, false]}), a == 2


### PR DESCRIPTION
Typo in constant breaks `==` operation

```ruby
Polars::DataFrame.new([a: 1]) == Polars::DataFrame.new([b: 1])
uninitialized constant Polars::DataFrame::ArgmentError (NameError)
Did you mean?  ArgumentError
```