### PR TITLE
Support truncate_ragged_lines option for reading CSV files

### DIFF
--- a/ext/polars/src/batched_csv.rs
+++ b/ext/polars/src/batched_csv.rs
@@ -93,7 +93,6 @@ impl RbBatchedCsv {
             .with_separator(separator.as_bytes()[0])
             .with_skip_rows(skip_rows)
             .with_ignore_errors(ignore_errors)
-            .truncate_ragged_lines(truncate_ragged_lines)
             .with_projection(projection)
             .with_rechunk(rechunk)
             .with_chunk_size(chunk_size)
@@ -109,7 +108,8 @@ impl RbBatchedCsv {
             .with_end_of_line_char(eol_char)
             .with_skip_rows_after_header(skip_rows_after_header)
             .with_row_index(row_index)
-            .sample_size(sample_size);
+            .sample_size(sample_size)
+            .truncate_ragged_lines(truncate_ragged_lines);
 
         let reader = if low_memory {
             let reader = reader

--- a/ext/polars/src/batched_csv.rs
+++ b/ext/polars/src/batched_csv.rs
@@ -49,6 +49,7 @@ impl RbBatchedCsv {
         let row_index = Option::<(String, IdxSize)>::try_convert(arguments[21])?;
         let sample_size = usize::try_convert(arguments[22])?;
         let eol_char = String::try_convert(arguments[23])?;
+        let truncate_ragged_lines = bool::try_convert(arguments[24])?;
         // end arguments
 
         let null_values = null_values.map(|w| w.0);
@@ -92,6 +93,7 @@ impl RbBatchedCsv {
             .with_separator(separator.as_bytes()[0])
             .with_skip_rows(skip_rows)
             .with_ignore_errors(ignore_errors)
+            .truncate_ragged_lines(truncate_ragged_lines)
             .with_projection(projection)
             .with_rechunk(rechunk)
             .with_chunk_size(chunk_size)

--- a/ext/polars/src/dataframe.rs
+++ b/ext/polars/src/dataframe.rs
@@ -136,6 +136,7 @@ impl RbDataFrame {
         let row_index = Option::<(String, IdxSize)>::try_convert(arguments[22])?;
         let sample_size = usize::try_convert(arguments[23])?;
         let eol_char = String::try_convert(arguments[24])?;
+        let truncate_ragged_lines = bool::try_convert(arguments[25])?;
         // end arguments
 
         let null_values = null_values.map(|w| w.0);
@@ -178,6 +179,7 @@ impl RbDataFrame {
             .with_separator(separator.as_bytes()[0])
             .with_skip_rows(skip_rows)
             .with_ignore_errors(ignore_errors)
+            .truncate_ragged_lines(truncate_ragged_lines)
             .with_projection(projection)
             .with_rechunk(rechunk)
             .with_chunk_size(chunk_size)

--- a/ext/polars/src/dataframe.rs
+++ b/ext/polars/src/dataframe.rs
@@ -179,7 +179,6 @@ impl RbDataFrame {
             .with_separator(separator.as_bytes()[0])
             .with_skip_rows(skip_rows)
             .with_ignore_errors(ignore_errors)
-            .truncate_ragged_lines(truncate_ragged_lines)
             .with_projection(projection)
             .with_rechunk(rechunk)
             .with_chunk_size(chunk_size)
@@ -198,6 +197,7 @@ impl RbDataFrame {
             .with_skip_rows_after_header(skip_rows_after_header)
             .with_row_index(row_index)
             .sample_size(sample_size)
+            .truncate_ragged_lines(truncate_ragged_lines)
             .finish()
             .map_err(RbPolarsErr::from)?;
         Ok(df.into())

--- a/ext/polars/src/lazyframe/mod.rs
+++ b/ext/polars/src/lazyframe/mod.rs
@@ -100,6 +100,7 @@ impl RbLazyFrame {
         let row_index = Option::<(String, IdxSize)>::try_convert(arguments[17])?;
         let try_parse_dates = bool::try_convert(arguments[18])?;
         let eol_char = String::try_convert(arguments[19])?;
+        let truncate_ragged_lines = bool::try_convert(arguments[20])?;
         // end arguments
 
         let null_values = null_values.map(|w| w.0);
@@ -120,6 +121,7 @@ impl RbLazyFrame {
             .with_separator(separator)
             .has_header(has_header)
             .with_ignore_errors(ignore_errors)
+            .truncate_ragged_lines(truncate_ragged_lines)
             .with_skip_rows(skip_rows)
             .with_n_rows(n_rows)
             .with_cache(cache)

--- a/ext/polars/src/lazyframe/mod.rs
+++ b/ext/polars/src/lazyframe/mod.rs
@@ -121,7 +121,6 @@ impl RbLazyFrame {
             .with_separator(separator)
             .has_header(has_header)
             .with_ignore_errors(ignore_errors)
-            .truncate_ragged_lines(truncate_ragged_lines)
             .with_skip_rows(skip_rows)
             .with_n_rows(n_rows)
             .with_cache(cache)
@@ -135,7 +134,8 @@ impl RbLazyFrame {
             .with_encoding(encoding.0)
             .with_row_index(row_index)
             .with_try_parse_dates(try_parse_dates)
-            .with_null_values(null_values);
+            .with_null_values(null_values)
+            .truncate_ragged_lines(truncate_ragged_lines);
 
         if let Some(_lambda) = with_schema_modify {
             todo!();

--- a/lib/polars/batched_csv_reader.rb
+++ b/lib/polars/batched_csv_reader.rb
@@ -14,7 +14,6 @@ module Polars
       dtypes: nil,
       null_values: nil,
       ignore_errors: false,
-      truncate_ragged_lines: false,
       parse_dates: false,
       n_threads: nil,
       infer_schema_length: 100,
@@ -28,7 +27,8 @@ module Polars
       row_count_offset: 0,
       sample_size: 1024,
       eol_char: "\n",
-      new_columns: nil
+      new_columns: nil,
+      truncate_ragged_lines: false
     )
       if Utils.pathlike?(file)
         path = Utils.normalise_filepath(file)

--- a/lib/polars/batched_csv_reader.rb
+++ b/lib/polars/batched_csv_reader.rb
@@ -14,6 +14,7 @@ module Polars
       dtypes: nil,
       null_values: nil,
       ignore_errors: false,
+      truncate_ragged_lines: false,
       parse_dates: false,
       n_threads: nil,
       infer_schema_length: 100,
@@ -75,7 +76,8 @@ module Polars
         skip_rows_after_header,
         Utils._prepare_row_count_args(row_count_name, row_count_offset),
         sample_size,
-        eol_char
+        eol_char,
+        truncate_ragged_lines
       )
       self.new_columns = new_columns
     end

--- a/lib/polars/data_frame.rb
+++ b/lib/polars/data_frame.rb
@@ -79,6 +79,7 @@ module Polars
       dtypes: nil,
       null_values: nil,
       ignore_errors: false,
+      truncate_ragged_lines: false,
       parse_dates: false,
       n_threads: nil,
       infer_schema_length: 100,
@@ -140,6 +141,7 @@ module Polars
           dtypes: dtypes_dict,
           null_values: null_values,
           ignore_errors: ignore_errors,
+          truncate_ragged_lines: truncate_ragged_lines,
           infer_schema_length: infer_schema_length,
           n_rows: n_rows,
           low_memory: low_memory,
@@ -186,7 +188,8 @@ module Polars
           skip_rows_after_header,
           Utils._prepare_row_count_args(row_count_name, row_count_offset),
           sample_size,
-          eol_char
+          eol_char,
+          truncate_ragged_lines
         )
       )
     end

--- a/lib/polars/data_frame.rb
+++ b/lib/polars/data_frame.rb
@@ -79,7 +79,6 @@ module Polars
       dtypes: nil,
       null_values: nil,
       ignore_errors: false,
-      truncate_ragged_lines: false,
       parse_dates: false,
       n_threads: nil,
       infer_schema_length: 100,
@@ -92,7 +91,8 @@ module Polars
       row_count_name: nil,
       row_count_offset: 0,
       sample_size: 1024,
-      eol_char: "\n"
+      eol_char: "\n",
+      truncate_ragged_lines: false
     )
       if Utils.pathlike?(file)
         path = Utils.normalise_filepath(file)

--- a/lib/polars/data_frame.rb
+++ b/lib/polars/data_frame.rb
@@ -141,7 +141,6 @@ module Polars
           dtypes: dtypes_dict,
           null_values: null_values,
           ignore_errors: ignore_errors,
-          truncate_ragged_lines: truncate_ragged_lines,
           infer_schema_length: infer_schema_length,
           n_rows: n_rows,
           low_memory: low_memory,
@@ -149,7 +148,8 @@ module Polars
           skip_rows_after_header: skip_rows_after_header,
           row_count_name: row_count_name,
           row_count_offset: row_count_offset,
-          eol_char: eol_char
+          eol_char: eol_char,
+          truncate_ragged_lines: truncate_ragged_lines
         )
         if columns.nil?
           return _from_rbdf(scan.collect._df)

--- a/lib/polars/io.rb
+++ b/lib/polars/io.rb
@@ -38,6 +38,8 @@ module Polars
     #   Try to keep reading lines if some lines yield errors.
     #   First try `infer_schema_length: 0` to read all columns as
     #   `:str` to check which values might cause an issue.
+    # @param truncate_ragged_lines [Boolean]
+    #   Truncate lines that are longer than the schema.
     # @param parse_dates [Boolean]
     #   Try to automatically parse dates. If this does not succeed,
     #   the column remains of data type `:str`.
@@ -100,6 +102,7 @@ module Polars
       dtypes: nil,
       null_values: nil,
       ignore_errors: false,
+      truncate_ragged_lines: false,
       parse_dates: false,
       n_threads: nil,
       infer_schema_length: 100,
@@ -149,6 +152,7 @@ module Polars
           dtypes: dtypes,
           null_values: null_values,
           ignore_errors: ignore_errors,
+          truncate_ragged_lines: truncate_ragged_lines,
           parse_dates: parse_dates,
           n_threads: n_threads,
           infer_schema_length: infer_schema_length,
@@ -208,6 +212,8 @@ module Polars
     #   Try to keep reading lines if some lines yield errors.
     #   First try `infer_schema_length: 0` to read all columns as
     #   `:str` to check which values might cause an issue.
+    # @param truncate_ragged_lines [Boolean]
+    #   Truncate lines that are longer than the schema.
     # @param cache [Boolean]
     #   Cache the result after reading.
     # @param with_column_names [Object]
@@ -251,6 +257,7 @@ module Polars
       dtypes: nil,
       null_values: nil,
       ignore_errors: false,
+      truncate_ragged_lines: false,
       cache: true,
       with_column_names: nil,
       infer_schema_length: 100,
@@ -282,6 +289,7 @@ module Polars
         dtypes: dtypes,
         null_values: null_values,
         ignore_errors: ignore_errors,
+        truncate_ragged_lines: truncate_ragged_lines,
         cache: cache,
         with_column_names: with_column_names,
         infer_schema_length: infer_schema_length,
@@ -716,6 +724,8 @@ module Polars
     #   Try to keep reading lines if some lines yield errors.
     #   First try `infer_schema_length: 0` to read all columns as
     #   `:str` to check which values might cause an issue.
+    # @param truncate_ragged_lines [Boolean]
+    #   Truncate lines that are longer than the schema.
     # @param parse_dates [Boolean]
     #   Try to automatically parse dates. If this does not succeed,
     #   the column remains of data type `:str`.
@@ -775,6 +785,7 @@ module Polars
       dtypes: nil,
       null_values: nil,
       ignore_errors: false,
+      truncate_ragged_lines: false,
       parse_dates: false,
       n_threads: nil,
       infer_schema_length: 100,
@@ -814,6 +825,7 @@ module Polars
         dtypes: dtypes,
         null_values: null_values,
         ignore_errors: ignore_errors,
+        truncate_ragged_lines: truncate_ragged_lines,
         parse_dates: parse_dates,
         n_threads: n_threads,
         infer_schema_length: infer_schema_length,

--- a/lib/polars/io.rb
+++ b/lib/polars/io.rb
@@ -38,8 +38,6 @@ module Polars
     #   Try to keep reading lines if some lines yield errors.
     #   First try `infer_schema_length: 0` to read all columns as
     #   `:str` to check which values might cause an issue.
-    # @param truncate_ragged_lines [Boolean]
-    #   Truncate lines that are longer than the schema.
     # @param parse_dates [Boolean]
     #   Try to automatically parse dates. If this does not succeed,
     #   the column remains of data type `:str`.
@@ -82,6 +80,8 @@ module Polars
     #   allocation needed.
     # @param eol_char [String]
     #   Single byte end of line character.
+    # @param truncate_ragged_lines [Boolean]
+    #   Truncate lines that are longer than the schema.
     #
     # @return [DataFrame]
     #
@@ -152,7 +152,6 @@ module Polars
           dtypes: dtypes,
           null_values: null_values,
           ignore_errors: ignore_errors,
-          truncate_ragged_lines: truncate_ragged_lines,
           parse_dates: parse_dates,
           n_threads: n_threads,
           infer_schema_length: infer_schema_length,
@@ -165,7 +164,8 @@ module Polars
           row_count_name: row_count_name,
           row_count_offset: row_count_offset,
           sample_size: sample_size,
-          eol_char: eol_char
+          eol_char: eol_char,
+          truncate_ragged_lines: truncate_ragged_lines
         )
       end
 
@@ -212,8 +212,6 @@ module Polars
     #   Try to keep reading lines if some lines yield errors.
     #   First try `infer_schema_length: 0` to read all columns as
     #   `:str` to check which values might cause an issue.
-    # @param truncate_ragged_lines [Boolean]
-    #   Truncate lines that are longer than the schema.
     # @param cache [Boolean]
     #   Cache the result after reading.
     # @param with_column_names [Object]
@@ -245,6 +243,8 @@ module Polars
     #   the column remains of data type `:str`.
     # @param eol_char [String]
     #   Single byte end of line character.
+    # @param truncate_ragged_lines [Boolean]
+    #   Truncate lines that are longer than the schema.
     #
     # @return [LazyFrame]
     def scan_csv(
@@ -289,7 +289,6 @@ module Polars
         dtypes: dtypes,
         null_values: null_values,
         ignore_errors: ignore_errors,
-        truncate_ragged_lines: truncate_ragged_lines,
         cache: cache,
         with_column_names: with_column_names,
         infer_schema_length: infer_schema_length,
@@ -302,6 +301,7 @@ module Polars
         row_count_offset: row_count_offset,
         parse_dates: parse_dates,
         eol_char: eol_char,
+        truncate_ragged_lines: truncate_ragged_lines
       )
     end
 
@@ -724,8 +724,6 @@ module Polars
     #   Try to keep reading lines if some lines yield errors.
     #   First try `infer_schema_length: 0` to read all columns as
     #   `:str` to check which values might cause an issue.
-    # @param truncate_ragged_lines [Boolean]
-    #   Truncate lines that are longer than the schema.
     # @param parse_dates [Boolean]
     #   Try to automatically parse dates. If this does not succeed,
     #   the column remains of data type `:str`.
@@ -765,6 +763,8 @@ module Polars
     #   allocation needed.
     # @param eol_char [String]
     #   Single byte end of line character.
+    # @param truncate_ragged_lines [Boolean]
+    #   Truncate lines that are longer than the schema.
     #
     # @return [BatchedCsvReader]
     #
@@ -825,7 +825,6 @@ module Polars
         dtypes: dtypes,
         null_values: null_values,
         ignore_errors: ignore_errors,
-        truncate_ragged_lines: truncate_ragged_lines,
         parse_dates: parse_dates,
         n_threads: n_threads,
         infer_schema_length: infer_schema_length,
@@ -839,7 +838,8 @@ module Polars
         row_count_offset: row_count_offset,
         sample_size: sample_size,
         eol_char: eol_char,
-        new_columns: new_columns
+        new_columns: new_columns,
+        truncate_ragged_lines: truncate_ragged_lines
       )
     end
 

--- a/lib/polars/io.rb
+++ b/lib/polars/io.rb
@@ -102,7 +102,6 @@ module Polars
       dtypes: nil,
       null_values: nil,
       ignore_errors: false,
-      truncate_ragged_lines: false,
       parse_dates: false,
       n_threads: nil,
       infer_schema_length: 100,
@@ -116,7 +115,8 @@ module Polars
       row_count_name: nil,
       row_count_offset: 0,
       sample_size: 1024,
-      eol_char: "\n"
+      eol_char: "\n",
+      truncate_ragged_lines: false
     )
       Utils._check_arg_is_1byte("sep", sep, false)
       Utils._check_arg_is_1byte("comment_char", comment_char, false)
@@ -257,7 +257,6 @@ module Polars
       dtypes: nil,
       null_values: nil,
       ignore_errors: false,
-      truncate_ragged_lines: false,
       cache: true,
       with_column_names: nil,
       infer_schema_length: 100,
@@ -269,7 +268,8 @@ module Polars
       row_count_name: nil,
       row_count_offset: 0,
       parse_dates: false,
-      eol_char: "\n"
+      eol_char: "\n",
+      truncate_ragged_lines: false
     )
       Utils._check_arg_is_1byte("sep", sep, false)
       Utils._check_arg_is_1byte("comment_char", comment_char, false)
@@ -785,7 +785,6 @@ module Polars
       dtypes: nil,
       null_values: nil,
       ignore_errors: false,
-      truncate_ragged_lines: false,
       parse_dates: false,
       n_threads: nil,
       infer_schema_length: 100,
@@ -798,7 +797,8 @@ module Polars
       row_count_name: nil,
       row_count_offset: 0,
       sample_size: 1024,
-      eol_char: "\n"
+      eol_char: "\n",
+      truncate_ragged_lines: false
     )
       projection, columns = Utils.handle_projection_columns(columns)
 

--- a/lib/polars/lazy_frame.rb
+++ b/lib/polars/lazy_frame.rb
@@ -38,7 +38,6 @@ module Polars
       dtypes: nil,
       null_values: nil,
       ignore_errors: false,
-      truncate_ragged_lines: false,
       cache: true,
       with_column_names: nil,
       infer_schema_length: 100,
@@ -50,7 +49,8 @@ module Polars
       row_count_name: nil,
       row_count_offset: 0,
       parse_dates: false,
-      eol_char: "\n"
+      eol_char: "\n",
+      truncate_ragged_lines: true
     )
       dtype_list = nil
       if !dtypes.nil?

--- a/lib/polars/lazy_frame.rb
+++ b/lib/polars/lazy_frame.rb
@@ -38,6 +38,7 @@ module Polars
       dtypes: nil,
       null_values: nil,
       ignore_errors: false,
+      truncate_ragged_lines: false,
       cache: true,
       with_column_names: nil,
       infer_schema_length: 100,
@@ -81,7 +82,8 @@ module Polars
           encoding,
           Utils._prepare_row_count_args(row_count_name, row_count_offset),
           parse_dates,
-          eol_char
+          eol_char,
+          truncate_ragged_lines
         )
       )
     end


### PR DESCRIPTION
Hi,

Thanks for the library! I'm getting good use out of it.

Polars can give an error message like:

```
found more fields than defined in 'Schema' (RuntimeError)

Consider setting 'truncate_ragged_lines=true'.
```

This PR adds support for it in the bindings.